### PR TITLE
Use abs path for ex_files

### DIFF
--- a/shipgrav/tests/test_grav_data.py
+++ b/shipgrav/tests/test_grav_data.py
@@ -14,10 +14,14 @@ from glob import glob
 
 
 class gravDataTestCase(unittest.TestCase):
+    @property
+    def ex_files(self):
+        return __file__.rsplit("/", 1)[0] + "/ex_files"
+
     def setUp(self):  # actions to take before running each test: load in some test data
         # test data is part of one of the files supplied by DGS (original file is 30M/86400
         # lines for 24 hr; we cut to 1 hr?)
-        gfiles = glob('ex_files/DGStest*.dat')
+        gfiles = glob(f'{self.ex_files}/DGStest*.dat')
         data = sgi.read_dgs_laptop(gfiles, 'DGStest')
         data['tsec'] = [e.timestamp()
                         for e in data['date_time']]  # get posix timestamps

--- a/shipgrav/tests/test_io.py
+++ b/shipgrav/tests/test_io.py
@@ -9,31 +9,35 @@ import shipgrav.io as sgi
 
 
 class ioTestCase(unittest.TestCase):
+    @property
+    def ex_files(self):
+        return __file__.rsplit("/", 1)[0] + "/ex_files"
+
     def test_read_nav(self):  # NOTE only tests one of the ship functions
         # but it does include extracting clock time -> datetime -> posix
-        nav = sgi.read_nav('Thompson', 'ex_files/TN400_nav.Raw')
+        nav = sgi.read_nav('Thompson', f'{self.ex_files}/TN400_nav.Raw')
         self.assertEqual(nav.iloc[0].time_sec, 1647129603)
         self.assertTrue(nav.iloc[0].lon + 118.6524 < 0.001)
 
     def test_read_bgm_rgs(self):
-        bgm = sgi.read_bgm_rgs('ex_files/AT05_01_bgm.RGS', 'Atlantis')
+        bgm = sgi.read_bgm_rgs(f'{self.ex_files}/AT05_01_bgm.RGS', 'Atlantis')
         self.assertEqual(bgm.iloc[0]['date_time'].timestamp(), 1656633600.445)
         self.assertEqual(bgm.iloc[0]['grav'], 980329.272)
 
     def test_read_bgm_raw(self):
-        bgm = sgi.read_bgm_raw('ex_files/TN400_bgm.Raw', 'Thompson')
+        bgm = sgi.read_bgm_raw(f'{self.ex_files}/TN400_bgm.Raw', 'Thompson')
         self.assertEqual(bgm.iloc[0]['date_time'].timestamp(), 1647129602.449)
         self.assertEqual(bgm.iloc[0]['counts'], 25529)
         self.assertEqual(bgm.iloc[0]['rgrav'], 127730.60800402702)
 
     def test_read_dgs_dat(self):
-        dgs = sgi.read_dgs_laptop('ex_files/DGStest_laptop.dat', 'DGStest')
+        dgs = sgi.read_dgs_laptop(f'{self.ex_files}/DGStest_laptop.dat', 'DGStest')
         self.assertEqual(dgs.iloc[0]['date_time'].timestamp(), 1562803200.0)
         self.assertEqual(dgs.iloc[0]['ve'], 0.81098)
         self.assertTrue(dgs.iloc[0]['rgrav'] - 12295.691114 < 0.0001)
 
     def test_read_dgs_raw(self):
-        dgs = sgi.read_dgs_raw('ex_files/SR2312_dgs_raw.txt', 'Ride')
+        dgs = sgi.read_dgs_raw(f'{self.ex_files}/SR2312_dgs_raw.txt', 'Ride')
         self.assertEqual(
             dgs.iloc[0]['date_time'].timestamp(), 1686873600.857719)
         self.assertEqual(dgs.iloc[0]['Gravity'], -218747)
@@ -41,7 +45,7 @@ class ioTestCase(unittest.TestCase):
 
     def test_read_mru(self):
         mru, cols = sgi.read_other_stuff(
-            'ex_files/IXBlue.yaml', 'ex_files/SR2312_mru.txt', 'PASHR')
+            f'{self.ex_files}/IXBlue.yaml', f'{self.ex_files}/SR2312_mru.txt', 'PASHR')
         self.assertEqual(mru.iloc[0]['Pitch:g'], -0.41)
         self.assertEqual(mru.iloc[0]['Roll:g'], 2.03)
         self.assertEqual(mru.iloc[0]['Heave:g'], -0.6)


### PR DESCRIPTION
Use absolute paths for test files so the suite can run from the root directory.

openjournals/joss-reviews#7358